### PR TITLE
Better mcbe window focused checks + virtual keys in config support implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 # Swim Mouse Cursor
-
 A lightweight Windows utility to fix Minecraft Bedrock Edition's 1.21.121 mouse cursor escaping issues by keeping it confined to the game window.
 
 ## 🎮 What Does This Do?
-
 This program automatically clips your mouse cursor to the Minecraft Bedrock window when the game is focused, preventing the cursor from escaping to other monitors or areas of your screen during gameplay. Works in both fullscreen and windowed modes!
 
 ## 📥 Installation
-
 1. Download the latest release from the [Releases](../../releases) page.
 2. Extract the `.exe` file to a folder of your choice.
 3. Run `SwimMouseCursor.exe`
@@ -26,20 +23,23 @@ This program automatically clips your mouse cursor to the Minecraft Bedrock wind
 - **Ctrl+Shift+C** - Toggle cursor clipping on/off.
 
 ### Configuration
-The program will create a `config.txt` file. You can edit this file to change and save the recenter key:
-- Open `config.txt`
-- Replace the letter with any key from A-Z or 0-9.
-- Save and restart the SwimMouseCursor program.
+The program will create a `config.txt` file on first run. You can edit this file to change the recenter key to any supported key:
 
-Example `config.txt`:
-```
-E
-```
+**Supported Key Formats:**
+- Single letters: `A` through `Z`
+- Number keys: `0` through `9`
+- Function keys: `F1` through `F12`
+- Special keys: `TAB`, `SPACE`, `ENTER`, `ESC`, `BACKSPACE`, `DELETE`, etc.
+- Arrow keys: `LEFT`, `RIGHT`, `UP`, `DOWN`
+- Modifier keys: `SHIFT`, `CTRL`, `ALT` (and their left/right variants)
+- Numpad keys: `NUMPAD0` through `NUMPAD9`
+- Virtual key names: `VK_TAB`, `VK_SPACE`, `VK_F1`, etc.
+
+**Case insensitive** - `TAB`, `tab`, and `Tab` all work!
 
 ## 🔧 Troubleshooting
 
 ### Windows Defender or Antivirus Blocking
-
 If Windows Defender or your antivirus software blocks the program:
 
 1. **Windows Defender SmartScreen:**
@@ -69,8 +69,14 @@ If you get an error like "The code execution cannot proceed because MSVCP140.dll
 3. Restart your computer
 4. Try running the program again
 
-### Cursor Still Escaping
+### Invalid Key Name Error
 
+If you see `[!] Invalid key name in config` in the console:
+- Check that your key name is spelled correctly in `config.txt`
+- Refer to the supported keys list above
+- The program will default to 'E' if an invalid key is specified
+
+### Cursor Still Escaping
 - Make sure the program is running (check for the console window)
 - Verify Minecraft Bedrock is the focused window
 - Check that clipping is enabled (should say "ENABLED" in console)
@@ -78,27 +84,25 @@ If you get an error like "The code execution cannot proceed because MSVCP140.dll
 - If all else fails, press `Ctrl+Shift+C` to toggle clipping off and on again
 
 ## 🎯 Features
-
 - ✅ Automatic cursor clipping when Minecraft is focused
 - ✅ Works in fullscreen AND windowed modes
 - ✅ Non-intrusive hotkey system (doesn't consume keypresses)
-- ✅ Configurable recenter key
+- ✅ Extensive configurable recenter key support (letters, numbers, function keys, special keys)
 - ✅ Safety toggle to disable clipping
 - ✅ Minimal CPU usage/overhead
 - ✅ Clean console interface with status updates
+- ✅ Intelligent window detection (only clips when Minecraft is truly visible and topmost)
 
 ## 💬 Support
-
 Join our Discord: [discord.gg/swim](https://discord.gg/swim)
 
 Play our MCPE Server: **swimgg.club**
 
 ## 📝 Credits
-
 Created by Swedeachu, aka Swimfan72
 
 ## ⚠️ Notes
-
 - This program is designed specifically for Minecraft Bedrock Edition (Windows 10/11).
 - The program must remain running in the background while you play.
 - Close the program or use `Ctrl+Shift+C` to release the cursor when done playing.
+- The recenter hotkey does NOT consume the keypress - it passes through to Minecraft.

--- a/SwimMouseCursor.cpp
+++ b/SwimMouseCursor.cpp
@@ -85,6 +85,86 @@ static bool IsMinecraftWindow(HWND hwnd)
 	return wcsstr(title, L"Minecraft") != nullptr;
 }
 
+static bool IsWindowActuallyVisibleAndTopmost(HWND hwnd)
+{
+	if (!hwnd || !IsWindow(hwnd) || !IsWindowVisible(hwnd))
+		return false;
+
+	// Check if the window is minimized
+	if (IsIconic(hwnd))
+		return false;
+
+	// CRITICAL: Window must be the actual foreground window receiving input
+	HWND fgWindow = GetForegroundWindow();
+	if (fgWindow != hwnd)
+		return false;
+
+	// Get the window rect
+	RECT windowRect{};
+	if (!GetWindowRect(hwnd, &windowRect))
+		return false;
+
+	// Check if window has any visible area
+	if (windowRect.right <= windowRect.left || windowRect.bottom <= windowRect.top)
+		return false;
+
+	// Additional check: Get the GUI thread info to verify focus
+	GUITHREADINFO gti = { sizeof(GUITHREADINFO) };
+	DWORD windowThreadId = GetWindowThreadProcessId(hwnd, nullptr);
+	if (GetGUIThreadInfo(windowThreadId, &gti))
+	{
+		// If there's an active window in the thread, it should match our window
+		if (gti.hwndActive && gti.hwndActive != hwnd)
+		{
+			// Check if active window belongs to same root
+			HWND activeRoot = GetAncestor(gti.hwndActive, GA_ROOT);
+			HWND ourRoot = GetAncestor(hwnd, GA_ROOT);
+			if (activeRoot != ourRoot)
+				return false;
+		}
+	}
+
+	// Sample multiple points across the window to ensure it's actually visible
+	// This catches cases where another window is layered on top
+	int numChecks = 0;
+	int passedChecks = 0;
+
+	for (int x = windowRect.left + 10; x < windowRect.right - 10; x += (windowRect.right - windowRect.left) / 4)
+	{
+		for (int y = windowRect.top + 10; y < windowRect.bottom - 10; y += (windowRect.bottom - windowRect.top) / 4)
+		{
+			numChecks++;
+			POINT pt = { x, y };
+			HWND windowAtPoint = WindowFromPoint(pt);
+
+			if (windowAtPoint)
+			{
+				HWND rootAtPoint = GetAncestor(windowAtPoint, GA_ROOT);
+				HWND rootMinecraft = GetAncestor(hwnd, GA_ROOT);
+
+				if (rootAtPoint == rootMinecraft)
+					passedChecks++;
+			}
+		}
+	}
+
+	// At least 75% of sampled points must belong to Minecraft
+	if (numChecks > 0 && passedChecks < (numChecks * 3 / 4))
+		return false;
+
+	// Final check: Verify no other window has captured input
+	HWND captureWindow = GetCapture();
+	if (captureWindow && captureWindow != hwnd)
+	{
+		HWND captureRoot = GetAncestor(captureWindow, GA_ROOT);
+		HWND ourRoot = GetAncestor(hwnd, GA_ROOT);
+		if (captureRoot != ourRoot)
+			return false;
+	}
+
+	return true;
+}
+
 static bool GetWindowClipRect(HWND hwnd, RECT& outClipRect)
 {
 	if (!IsWindow(hwnd) || !IsWindowVisible(hwnd)) return false;
@@ -194,8 +274,8 @@ static LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lP
 		{
 			HWND fg = GetForegroundWindow();
 
-			// Check if Minecraft is focused
-			if (fg && IsMinecraftWindow(fg))
+			// Check if Minecraft is focused AND actually visible
+			if (fg && IsMinecraftWindow(fg) && IsWindowActuallyVisibleAndTopmost(fg))
 			{
 				// Check if it's the recenter key OR escape key
 				if (kb->vkCode == recenterKey || kb->vkCode == VK_ESCAPE)
@@ -260,7 +340,7 @@ int wmain(int argc, wchar_t** argv)
 	}
 
 	Log(L"[*] CursorClipperConsole running. Looking for: %s", TARGET_EXE);
-	Log(L"[*] Will clip cursor whenever Minecraft window is focused (fullscreen OR windowed).");
+	Log(L"[*] Will clip cursor whenever Minecraft window is focused AND visible on screen.");
 	Log(L"[*] Clipping is currently: ENABLED");
 
 	// We'll pump messages only for hotkey; foreground tracking is via polling.
@@ -336,7 +416,8 @@ int wmain(int argc, wchar_t** argv)
 				lastActive = fg;
 			}
 
-			if (fg && IsMinecraftWindow(fg))
+			// Check if Minecraft is foreground AND actually visible
+			if (fg && IsMinecraftWindow(fg) && IsWindowActuallyVisibleAndTopmost(fg))
 			{
 				RECT clip{};
 				if (GetWindowClipRect(fg, clip))
@@ -356,6 +437,7 @@ int wmain(int argc, wchar_t** argv)
 				{
 					ClipCursor(nullptr);
 					lastClipped = false;
+					Log(L"[-] Minecraft not visible — cursor released.");
 				}
 			}
 		}

--- a/SwimMouseCursor.vcxproj
+++ b/SwimMouseCursor.vcxproj
@@ -129,6 +129,9 @@
   <ItemGroup>
     <ClCompile Include="SwimMouseCursor.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="VirtualKeyParser.h" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/SwimMouseCursor.vcxproj.filters
+++ b/SwimMouseCursor.vcxproj.filters
@@ -5,10 +5,18 @@
       <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
       <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
     </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{1c90eb41-ca46-47d2-a1b6-2a9b741793a1}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="SwimMouseCursor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="VirtualKeyParser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/VirtualKeyParser.h
+++ b/VirtualKeyParser.h
@@ -1,0 +1,194 @@
+// VirtualKeyParser.h
+// Header file for translating string key names to Windows Virtual Key codes
+// Supports common key names, virtual key names (VK_*), and single characters
+
+#pragma once
+#include <windows.h>
+#include <string>
+#include <unordered_map>
+#include <algorithm>
+#include <cctype>
+
+namespace VirtualKeyParser
+{
+
+	// Convert string to uppercase for case-insensitive comparison
+	inline std::string ToUpper(const std::string& str)
+	{
+		std::string result = str;
+		std::transform(result.begin(), result.end(), result.begin(),
+			[](unsigned char c) { return std::toupper(c); });
+		return result;
+	}
+
+	// Map of common key name strings to virtual key codes
+	inline const std::unordered_map<std::string, WORD>& GetKeyNameMap()
+	{
+		static const std::unordered_map<std::string, WORD> keyMap = {
+			// Letter keys (A-Z)
+			{"A", 'A'}, {"B", 'B'}, {"C", 'C'}, {"D", 'D'}, {"E", 'E'},
+			{"F", 'F'}, {"G", 'G'}, {"H", 'H'}, {"I", 'I'}, {"J", 'J'},
+			{"K", 'K'}, {"L", 'L'}, {"M", 'M'}, {"N", 'N'}, {"O", 'O'},
+			{"P", 'P'}, {"Q", 'Q'}, {"R", 'R'}, {"S", 'S'}, {"T", 'T'},
+			{"U", 'U'}, {"V", 'V'}, {"W", 'W'}, {"X", 'X'}, {"Y", 'Y'},
+			{"Z", 'Z'},
+
+			// Number keys (0-9)
+			{"0", '0'}, {"1", '1'}, {"2", '2'}, {"3", '3'}, {"4", '4'},
+			{"5", '5'}, {"6", '6'}, {"7", '7'}, {"8", '8'}, {"9", '9'},
+
+			// Function keys
+			{"F1", VK_F1}, {"F2", VK_F2}, {"F3", VK_F3}, {"F4", VK_F4},
+			{"F5", VK_F5}, {"F6", VK_F6}, {"F7", VK_F7}, {"F8", VK_F8},
+			{"F9", VK_F9}, {"F10", VK_F10}, {"F11", VK_F11}, {"F12", VK_F12},
+			{"VK_F1", VK_F1}, {"VK_F2", VK_F2}, {"VK_F3", VK_F3}, {"VK_F4", VK_F4},
+			{"VK_F5", VK_F5}, {"VK_F6", VK_F6}, {"VK_F7", VK_F7}, {"VK_F8", VK_F8},
+			{"VK_F9", VK_F9}, {"VK_F10", VK_F10}, {"VK_F11", VK_F11}, {"VK_F12", VK_F12},
+
+			// Special keys
+			{"SPACE", VK_SPACE}, {"VK_SPACE", VK_SPACE}, {"SPACEBAR", VK_SPACE},
+			{"ENTER", VK_RETURN}, {"VK_RETURN", VK_RETURN}, {"RETURN", VK_RETURN},
+			{"VK_ENTER", VK_RETURN},
+			{"TAB", VK_TAB}, {"VK_TAB", VK_TAB},
+			{"ESC", VK_ESCAPE}, {"ESCAPE", VK_ESCAPE}, {"VK_ESCAPE", VK_ESCAPE},
+			{"BACKSPACE", VK_BACK}, {"VK_BACK", VK_BACK}, {"BACK", VK_BACK},
+			{"DELETE", VK_DELETE}, {"VK_DELETE", VK_DELETE}, {"DEL", VK_DELETE},
+			{"INSERT", VK_INSERT}, {"VK_INSERT", VK_INSERT}, {"INS", VK_INSERT},
+			{"HOME", VK_HOME}, {"VK_HOME", VK_HOME},
+			{"END", VK_END}, {"VK_END", VK_END},
+			{"PAGEUP", VK_PRIOR}, {"VK_PRIOR", VK_PRIOR}, {"PGUP", VK_PRIOR},
+			{"PAGEDOWN", VK_NEXT}, {"VK_NEXT", VK_NEXT}, {"PGDN", VK_NEXT},
+
+			// Arrow keys
+			{"LEFT", VK_LEFT}, {"VK_LEFT", VK_LEFT},
+			{"RIGHT", VK_RIGHT}, {"VK_RIGHT", VK_RIGHT},
+			{"UP", VK_UP}, {"VK_UP", VK_UP},
+			{"DOWN", VK_DOWN}, {"VK_DOWN", VK_DOWN},
+
+			// Modifier keys
+			{"SHIFT", VK_SHIFT}, {"VK_SHIFT", VK_SHIFT},
+			{"LSHIFT", VK_LSHIFT}, {"VK_LSHIFT", VK_LSHIFT},
+			{"RSHIFT", VK_RSHIFT}, {"VK_RSHIFT", VK_RSHIFT},
+			{"CTRL", VK_CONTROL}, {"CONTROL", VK_CONTROL}, {"VK_CONTROL", VK_CONTROL},
+			{"LCTRL", VK_LCONTROL}, {"LCONTROL", VK_LCONTROL}, {"VK_LCONTROL", VK_LCONTROL},
+			{"RCTRL", VK_RCONTROL}, {"RCONTROL", VK_RCONTROL}, {"VK_RCONTROL", VK_RCONTROL},
+			{"ALT", VK_MENU}, {"VK_MENU", VK_MENU},
+			{"LALT", VK_LMENU}, {"VK_LMENU", VK_LMENU},
+			{"RALT", VK_RMENU}, {"VK_RMENU", VK_RMENU},
+
+			// Numpad keys
+			{"NUMPAD0", VK_NUMPAD0}, {"VK_NUMPAD0", VK_NUMPAD0},
+			{"NUMPAD1", VK_NUMPAD1}, {"VK_NUMPAD1", VK_NUMPAD1},
+			{"NUMPAD2", VK_NUMPAD2}, {"VK_NUMPAD2", VK_NUMPAD2},
+			{"NUMPAD3", VK_NUMPAD3}, {"VK_NUMPAD3", VK_NUMPAD3},
+			{"NUMPAD4", VK_NUMPAD4}, {"VK_NUMPAD4", VK_NUMPAD4},
+			{"NUMPAD5", VK_NUMPAD5}, {"VK_NUMPAD5", VK_NUMPAD5},
+			{"NUMPAD6", VK_NUMPAD6}, {"VK_NUMPAD6", VK_NUMPAD6},
+			{"NUMPAD7", VK_NUMPAD7}, {"VK_NUMPAD7", VK_NUMPAD7},
+			{"NUMPAD8", VK_NUMPAD8}, {"VK_NUMPAD8", VK_NUMPAD8},
+			{"NUMPAD9", VK_NUMPAD9}, {"VK_NUMPAD9", VK_NUMPAD9},
+
+			// Punctuation and symbols
+			{"SEMICOLON", VK_OEM_1}, {"VK_OEM_1", VK_OEM_1},
+			{"PLUS", VK_OEM_PLUS}, {"VK_OEM_PLUS", VK_OEM_PLUS},
+			{"COMMA", VK_OEM_COMMA}, {"VK_OEM_COMMA", VK_OEM_COMMA},
+			{"MINUS", VK_OEM_MINUS}, {"VK_OEM_MINUS", VK_OEM_MINUS},
+			{"PERIOD", VK_OEM_PERIOD}, {"VK_OEM_PERIOD", VK_OEM_PERIOD},
+			{"SLASH", VK_OEM_2}, {"VK_OEM_2", VK_OEM_2},
+			{"TILDE", VK_OEM_3}, {"VK_OEM_3", VK_OEM_3},
+			{"LEFTBRACKET", VK_OEM_4}, {"VK_OEM_4", VK_OEM_4},
+			{"BACKSLASH", VK_OEM_5}, {"VK_OEM_5", VK_OEM_5},
+			{"RIGHTBRACKET", VK_OEM_6}, {"VK_OEM_6", VK_OEM_6},
+			{"QUOTE", VK_OEM_7}, {"VK_OEM_7", VK_OEM_7},
+		};
+		return keyMap;
+	}
+
+	// Parse a key name string and return the virtual key code
+	// Returns 0 if the key name is invalid
+	inline WORD ParseKeyName(const std::string& keyName)
+	{
+		if (keyName.empty())
+			return 0;
+
+		// Convert to uppercase for case-insensitive matching
+		std::string upperKey = ToUpper(keyName);
+
+		// Trim whitespace
+		while (!upperKey.empty() && std::isspace(static_cast<unsigned char>(upperKey.back())))
+			upperKey.pop_back();
+		while (!upperKey.empty() && std::isspace(static_cast<unsigned char>(upperKey.front())))
+			upperKey.erase(0, 1);
+
+		if (upperKey.empty())
+			return 0;
+
+		// Look up in the key map
+		const auto& keyMap = GetKeyNameMap();
+		auto it = keyMap.find(upperKey);
+		if (it != keyMap.end())
+		{
+			return it->second;
+		}
+
+		// If it's a single character A-Z or 0-9, return its virtual key code
+		if (upperKey.length() == 1)
+		{
+			char c = upperKey[0];
+			if ((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'))
+			{
+				return static_cast<WORD>(c);
+			}
+		}
+
+		// Not found
+		return 0;
+	}
+
+	// Get a human-readable name for a virtual key code
+	inline std::string GetKeyNameFromVK(WORD vkCode)
+	{
+		// Check single letters and numbers first
+		if ((vkCode >= 'A' && vkCode <= 'Z') || (vkCode >= '0' && vkCode <= '9'))
+		{
+			return std::string(1, static_cast<char>(vkCode));
+		}
+
+		// Special cases for common keys
+		switch (vkCode)
+		{
+			case VK_SPACE: return "SPACE";
+			case VK_RETURN: return "ENTER";
+			case VK_TAB: return "TAB";
+			case VK_ESCAPE: return "ESC";
+			case VK_BACK: return "BACKSPACE";
+			case VK_DELETE: return "DELETE";
+			case VK_INSERT: return "INSERT";
+			case VK_HOME: return "HOME";
+			case VK_END: return "END";
+			case VK_PRIOR: return "PAGEUP";
+			case VK_NEXT: return "PAGEDOWN";
+			case VK_LEFT: return "LEFT";
+			case VK_RIGHT: return "RIGHT";
+			case VK_UP: return "UP";
+			case VK_DOWN: return "DOWN";
+			case VK_SHIFT: return "SHIFT";
+			case VK_CONTROL: return "CTRL";
+			case VK_MENU: return "ALT";
+			case VK_F1: return "F1";
+			case VK_F2: return "F2";
+			case VK_F3: return "F3";
+			case VK_F4: return "F4";
+			case VK_F5: return "F5";
+			case VK_F6: return "F6";
+			case VK_F7: return "F7";
+			case VK_F8: return "F8";
+			case VK_F9: return "F9";
+			case VK_F10: return "F10";
+			case VK_F11: return "F11";
+			case VK_F12: return "F12";
+			default: return "UNKNOWN";
+		}
+	}
+
+}


### PR DESCRIPTION
Enhanced virtual key support for recenter hotkey configuration. The config.txt file now accepts a wide range of key names including function keys (F1-F12), special keys (TAB, SPACE, ENTER, ESC), arrow keys, modifier keys (SHIFT, CTRL, ALT), numpad keys, and VK_ prefixed names, with case-insensitive parsing. Additionally, improved window detection logic to prevent cursor clipping when Minecraft is not actually visible on screen (e.g., when Alt+Tabbed to another fullscreen application).